### PR TITLE
Make CIText inherit types.Concatenable

### DIFF
--- a/citext/__init__.py
+++ b/citext/__init__.py
@@ -4,7 +4,7 @@ import sqlalchemy.types as types
 from sqlalchemy.dialects.postgresql.base import ischema_names
 
 
-class CIText(types.UserDefinedType):
+class CIText(types.Concatenable, types.UserDefinedType):
 
     def get_col_spec(self):
         return 'CITEXT'

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     install_requires=[
         'SQLAlchemy>=0.6',
     ],
+    test_suite='tests',
     setup_requires=[],
     zip_safe=False,
     packages=find_packages(),

--- a/tests/test_citext.py
+++ b/tests/test_citext.py
@@ -1,0 +1,14 @@
+import unittest
+
+from sqlalchemy import Column
+
+from citext import CIText
+
+
+class TestCIText(unittest.TestCase):
+
+    def test_field_concatenable(self):
+        self.assertEqual(
+            str(Column(CIText(), name='field') + 'value'),
+            'field || :field_1'
+        )


### PR DESCRIPTION
This code:

```
>> from sqlalchemy import Column
>> from citext import CIText
>> print Column(CIText, name="field") + "whatever"
```

Without the inheritance, generates the invalid syntax:

```
field + :field_1
```

With the inheritance, generates a valid, working syntax:

```
field || :field_1
```

It is also problematic if you need to use "startswith":

```
>>> print Column(CIText, name="myfield").startswith("ABC")
myfield LIKE :myfield_1 + '%%'
```

Note you can still transform the filter to a literal as a workaround.

```
>>> print Column(CIText, name="myfield").startswith(literal("ABC"))
myfield LIKE :myfield_1 || '%%'
```