### PR TITLE
Don't install tests directory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,3 +91,4 @@ Contributors
 - `@dstufft <https://github.com/dstufft>`_
 - `@brmzkw <https://github.com/brmzkw>`_
 - `@graingert <https://github.com/graingert>`_
+- `@cjmayo <https://github.com/cjmayo>`_

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     license='BSD',
     setup_requires=[],
     zip_safe=False,
-    packages=find_packages(),
+    packages=['citext'],
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
Not needed by most users and it was being installed as its own package.

Setuptools documentation suggests not using find_packages() for
simple projects [1].

[1] https://setuptools.readthedocs.io/en/latest/setuptools.html#using-find-packages