### PR TITLE
Add a `literal_processor` method to the `CIText` class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,3 +92,4 @@ Contributors
 - `@brmzkw <https://github.com/brmzkw>`_
 - `@graingert <https://github.com/graingert>`_
 - `@cjmayo <https://github.com/cjmayo>`_
+- `@libre-man <https://github.com/libre-man>`_

--- a/citext/__init__.py
+++ b/citext/__init__.py
@@ -5,6 +5,18 @@ from sqlalchemy.dialects.postgresql.base import ischema_names
 
 
 class CIText(types.Concatenable, types.UserDefinedType):
+    # This is copied from the `literal_processor` of sqlalchemy's own `String`
+    # type.
+    def literal_processor(self, dialect):
+        def process(value):
+            value = value.replace("'", "''")
+
+            if dialect.identifier_preparer._double_percents:
+                value = value.replace("%", "%%")
+
+            return "'%s'" % value
+
+        return process
 
     def get_col_spec(self):
         return 'CITEXT'

--- a/tests/test_citext.py
+++ b/tests/test_citext.py
@@ -1,8 +1,8 @@
 import unittest
 
-from sqlalchemy import Column
-
 from citext import CIText
+from sqlalchemy import Column
+from sqlalchemy.dialects import postgresql
 
 
 class TestCIText(unittest.TestCase):
@@ -12,3 +12,20 @@ class TestCIText(unittest.TestCase):
             str(Column(CIText(), name='field') + 'value'),
             'field || :field_1'
         )
+
+    def test_field_compare_string(self):
+        self.assertEqual(
+            str(Column(CIText(), name='field') == 'NON_EXISTING'),
+            "field = :field_1")
+
+        self.assertEqual(
+            str((Column(CIText(), name='field') == 'NON_EXISTING').compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={'literal_binds': True})),
+            "field = 'NON_EXISTING'")
+
+        self.assertEqual(
+            str((Column(CIText(), name='field') == "NON|'_EXISTING%").compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={'literal_binds': True})),
+            "field = 'NON|''_EXISTING%%'")


### PR DESCRIPTION
This makes it possible to compile queries with `literal_binds` set to `True`.

This fixes #15.