### PR TITLE
Only import psycopg2 where it is used

### DIFF
--- a/citext/__init__.py
+++ b/citext/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-import psycopg2.extensions
 import sqlalchemy
 import sqlalchemy.types as types
 from sqlalchemy.dialects.postgresql.base import ischema_names
@@ -43,6 +42,8 @@ ischema_names['citext'] = CIText
 
 def register_citext_array(engine):
     """Call once with an engine for citext values to be returned as strings instead of characters"""
+    import psycopg2.extensions
+
     results = engine.execute(sqlalchemy.text("SELECT typarray FROM pg_type WHERE typname = 'citext'"))
     oids = tuple(row[0] for row in results)
     array_type = psycopg2.extensions.new_array_type(oids, 'citext[]', psycopg2.STRING)


### PR DESCRIPTION
Otherwise this module fails to import in environments where a different DB connector from psycopg2 is used. My current employer won't allow the use of pscyopg2 for licensing reasons (don't blame me, look to the legal department). So something like pg8000 needs to be used.

Importing this within the relevant function is a gross solution, but it seemed less gross to me than a try/except statement at the top of the file. However, I'm happy with any solution that doesn't require me to use the psycopg2 as my DB connector in order to use this extension module.