### PR TITLE
Update for SQLAlchemy>=2 compatibility

### DIFF
--- a/citext/__init__.py
+++ b/citext/__init__.py
@@ -43,7 +43,10 @@ ischema_names['citext'] = CIText
 
 def register_citext_array(engine):
     """Call once with an engine for citext values to be returned as strings instead of characters"""
-    results = engine.execute(sqlalchemy.text("SELECT typarray FROM pg_type WHERE typname = 'citext'"))
+    with engine.connect() as connection:
+        # Using engine.execute() is deprecated in SQLAlchemy >=1.4,<2, removed in >=2
+        # Using engine.connect().execute() is compatible with *all* SQLAlchemy >= 1.1 (and probably further back)
+        results = connection.execute(sqlalchemy.text("SELECT typarray FROM pg_type WHERE typname = 'citext'"))
     oids = tuple(row[0] for row in results)
     array_type = psycopg2.extensions.new_array_type(oids, 'citext[]', psycopg2.STRING)
     psycopg2.extensions.register_type(array_type, None)

--- a/citext/__init__.py
+++ b/citext/__init__.py
@@ -12,6 +12,7 @@ __version__ = '1.8.0'
 class CIText(types.Concatenable, types.UserDefinedType):
     # This is copied from the `literal_processor` of sqlalchemy's own `String`
     # type.
+    cache_ok = True
     def literal_processor(self, dialect):
         def process(value):
             value = value.replace("'", "''")


### PR DESCRIPTION
This is for #23 and fixes a hard break with SQLAlchemy >= 2. It also fixes deprecation warnings in SQLAlchemy>1.3,<2

I tested this for backwards compatibility on SQLalchemy 1.1, 1.2, and 1.3 and had no problems